### PR TITLE
FEAT: Multi input, multi model and JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ python wdv3_timm.py --model=all path/to/image_*.png --json --summary
 The JSON summary will look like :
 
 <details>
-  <summary>Click me to view JSON output for all 3 models !</summary>
+  <summary>Click me to view JSON summary !</summary>
 
 
 ```JSON

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ General tags (threshold=0.35):
 ## Do more with batch mode !
 Files will be processed without unloading the model, saving lots of time.
 
-
-It's possible to have all model be used one after the other. It is done by unloading and loading a new model after all the files where done with the previous model.
+It's possible to have multiple or all model be used one after the other.
+It is done by unloading and loading a new model after all the files where done with the previous model.
 
 ```sh
 # with file list you provide
@@ -96,6 +96,8 @@ python wdv3_timm.py --model=all path/to/image_1.png path/to/image_2.png path/to/
 python wdv3_timm.py --model=all path/to/image_*.png
 # or with glob that are handled by python, put in quotes
 python wdv3_timm.py --model=all "path/*/image_*.png"
+# only with selected models :
+python wdv3_timm.py --model=vit,convnext "path/*/image_*.png"
 
 ```
 ##  Save to JSON !
@@ -274,3 +276,138 @@ The JSON will look like :
 ```
 
 </details>
+
+
+### JSON summary
+Do you want to keep the highest tags from all different models ?
+Here you can, but it will ignore cutoff.
+Only works with `--json`
+
+Will also tell what models made the highest certainty for selected tags.
+For more control, you will have to write your own JSON parser.
+
+```sh
+# will create a filepath/filename.json file and summary
+python wdv3_timm.py --model=all path/to/image_*.png --json --summary
+```
+The JSON summary will look like :
+
+<details>
+  <summary>Click me to view JSON output for all 3 models !</summary>
+
+
+```JSON
+
+ {
+        "Summary": {
+            "General": {
+                "1girl": "0.9990073",
+                "solo": "0.99103117",
+                "horns": "0.97691685",
+                "blue_hair": "0.97018594",
+                "long_hair": "0.976655",
+                "detached_sleeves": "0.9630663",
+                "ahoge": "0.95730704",
+                "gloves": "0.95285827",
+                "purple_eyes": "0.9304822",
+                "bell": "0.9311429",
+                "orb": "0.94929373",
+                "breasts": "0.939335",
+                "looking_at_viewer": "0.90088356",
+                "black_gloves": "0.88976157",
+                "white_background": "0.8646937",
+                "bare_shoulders": "0.87559104",
+                "smile": "0.8828964",
+                "medium_breasts": "0.8694741",
+                "neck_bell": "0.79893",
+                "thighlet": "0.7304673",
+                "sidelocks": "0.7278657",
+                "vision_(genshin_impact)": "0.79898244",
+                "standing": "0.69712484",
+                "white_sleeves": "0.74657583",
+                "tassel": "0.7846296",
+                "gold_trim": "0.77870077",
+                "simple_background": "0.64645475",
+                "bow": "0.49510783",
+                "pantyhose": "0.60918343",
+                "waist_cape": "0.44340992",
+                "flower_knot": "0.55061",
+                "bodystocking": "0.6048321",
+                "feet_out_of_frame": "0.42403945",
+                "low_ponytail": "0.5833588",
+                "chinese_knot": "0.49119928",
+                "long_sleeves": "0.4037104"
+            },
+            "General_Models": {
+                "SmilingWolf/wd-swinv2-tagger-v3": [
+                    "1girl",
+                    "horns",
+                    "blue_hair",
+                    "long_hair",
+                    "detached_sleeves",
+                    "gloves",
+                    "breasts",
+                    "looking_at_viewer",
+                    "black_gloves",
+                    "white_background",
+                    "bare_shoulders",
+                    "smile",
+                    "medium_breasts",
+                    "vision_(genshin_impact)",
+                    "standing",
+                    "white_sleeves",
+                    "gold_trim",
+                    "pantyhose",
+                    "flower_knot",
+                    "low_ponytail",
+                    "chinese_knot",
+                    "long_sleeves"
+                ],
+                "SmilingWolf/wd-convnext-tagger-v3": [
+                    "solo",
+                    "ahoge",
+                    "bell",
+                    "orb",
+                    "neck_bell",
+                    "tassel",
+                    "simple_background",
+                    "bodystocking"
+                ],
+                "SmilingWolf/wd-vit-tagger-v3": [
+                    "purple_eyes",
+                    "thighlet",
+                    "sidelocks",
+                    "bow",
+                    "waist_cape",
+                    "feet_out_of_frame"
+                ]
+            },
+            "Ratings": {
+                "general": "0.17550515",
+                "sensitive": "0.9110725",
+                "questionable": "0.0012736674",
+                "explicit": "0.00019249438"
+            },
+            "Ratings_Models": {
+                "SmilingWolf/wd-vit-tagger-v3": [
+                    "general"
+                ],
+                "SmilingWolf/wd-swinv2-tagger-v3": [
+                    "sensitive",
+                    "questionable",
+                    "explicit"
+                ]
+            },
+            "Character": {
+                "ganyu_(genshin_impact)": "0.9917346"
+            },
+            "Character_Models": {
+                "SmilingWolf/wd-vit-tagger-v3": [
+                    "ganyu_(genshin_impact)"
+                ]
+            },
+            "Caption": "1girl, ahoge, bare_shoulders, bell, black_gloves, blue_hair, bodystocking, bow, breasts, chinese_knot, detached_sleeves, feet_out_of_frame, flower_knot, gloves, gold_trim, horns, long_hair, long_sleeves, looking_at_viewer, low_ponytail, medium_breasts, neck_bell, orb, pantyhose, purple_eyes, sidelocks, simple_background, smile, solo, standing, tassel, thighlet, vision_(genshin_impact), waist_cape, white_background, white_sleeves",
+            "Tags": "1girl, ahoge, bare_shoulders, bell, black_gloves, blue_hair, bodystocking, bow, breasts, chinese_knot, detached_sleeves, feet_out_of_frame, flower_knot, gloves, gold_trim, horns, long_hair, long_sleeves, looking_at_viewer, low_ponytail, medium_breasts, neck_bell, orb, pantyhose, purple_eyes, sidelocks, simple_background, smile, solo, standing, tassel, thighlet, vision_(genshin_impact), waist_cape, white_background, white_sleeves"
+        }
+    }
+```

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ python -m pip install torch torchvision torchaudio --index-url https://download.
 python -m pip install -r requirements.txt
 ```
 
-3. Run the example script, picking one of the 3 models to use:
+3. Run the example script, picking one of the 3 models to use or all of them:
 ```sh
-python wdv3_timm.py <swinv2|convnext|vit> path/to/image.png
+python wdv3_timm.py --model=<swinv2|convnext|vit|all> path/to/image.png
 ```
 
-Example output from `python wdv3_timm.py vit a_picture_of_ganyu.png`:
+Example output from `python wdv3_timm.py --model=vit a_picture_of_ganyu.png`:
 ```sh
 Loading model 'vit' from 'SmilingWolf/wd-vit-tagger-v3'...
 Loading tag list...
@@ -81,4 +81,26 @@ General tags (threshold=0.35):
   shirt: 0.427
   black_shirt: 0.417
   cowbell: 0.415
+```
+
+4. Do more with batch mode !
+Files will be processed without unloading the model, saving lots of time.
+It's possible to have all model be used, by unloading and loading a new model after all the files where done with the previous model.
+
+```sh
+# with file list created from shell
+python wdv3_timm.py --model=all path/to/image_*.png
+# or with glob that are handled by python, put in quotes
+python wdv3_timm.py --model=all "path/*/image_*.png"
+
+```
+5. Save to JSON !
+Save output to JSON in the same path that the file is with the same filename but with a .json extension.
+`--json` will disable printing the results, if you want them back, use `--print`.
+
+```sh
+# will create a filepath/filename.json file
+python wdv3_timm.py --model=all path/to/image_*.png --json
+# or to also print the results
+python wdv3_timm.py --model=all path/to/image_*.png --json --print
 ```

--- a/README.md
+++ b/README.md
@@ -83,20 +83,25 @@ General tags (threshold=0.35):
   cowbell: 0.415
 ```
 
-4. Do more with batch mode !
+## Do more with batch mode !
 Files will be processed without unloading the model, saving lots of time.
-It's possible to have all model be used, by unloading and loading a new model after all the files where done with the previous model.
+
+
+It's possible to have all model be used one after the other. It is done by unloading and loading a new model after all the files where done with the previous model.
 
 ```sh
+# with file list you provide
+python wdv3_timm.py --model=all path/to/image_1.png path/to/image_2.png path/to/image_3.png
 # with file list created from shell
 python wdv3_timm.py --model=all path/to/image_*.png
 # or with glob that are handled by python, put in quotes
 python wdv3_timm.py --model=all "path/*/image_*.png"
 
 ```
-5. Save to JSON !
+##  Save to JSON !
 Save output to JSON in the same path that the file is with the same filename but with a .json extension.
 `--json` will disable printing the results, if you want them back, use `--print`.
+If a JSON is already existant, it will append to it.
 
 ```sh
 # will create a filepath/filename.json file
@@ -104,3 +109,168 @@ python wdv3_timm.py --model=all path/to/image_*.png --json
 # or to also print the results
 python wdv3_timm.py --model=all path/to/image_*.png --json --print
 ```
+The JSON will look like :
+
+<details>
+  <summary>Click me to view JSON output for all 3 models !</summary>
+
+```JSON
+[
+    {
+        "Caption": "1girl, solo, horns, blue_hair, long_hair, detached_sleeves, ahoge, gloves, purple_eyes, bell, orb, breasts, looking_at_viewer, black_gloves, white_background, bare_shoulders, smile, medium_breasts, neck_bell, thighlet, sidelocks, vision_(genshin_impact), standing, white_sleeves, tassel, gold_trim, simple_background, bow, pantyhose, waist_cape, flower_knot, bodystocking, feet_out_of_frame, low_ponytail, chinese_knot, long_sleeves, ganyu_(genshin_impact)",
+        "Tags": "1girl, solo, horns, blue hair, long hair, detached sleeves, ahoge, gloves, purple eyes, bell, orb, breasts, looking at viewer, black gloves, white background, bare shoulders, smile, medium breasts, neck bell, thighlet, sidelocks, vision \\(genshin impact\\), standing, white sleeves, tassel, gold trim, simple background, bow, pantyhose, waist cape, flower knot, bodystocking, feet out of frame, low ponytail, chinese knot, long sleeves, ganyu \\(genshin impact\\)",
+        "Ratings": {
+            "general": "0.17550515",
+            "sensitive": "0.83533895",
+            "questionable": "0.0011807431",
+            "explicit": "0.00017911881"
+        },
+        "Character": {
+            "ganyu_(genshin_impact)": "0.9917346"
+        },
+        "General": {
+            "1girl": "0.99861884",
+            "solo": "0.9774026",
+            "horns": "0.9733339",
+            "blue_hair": "0.9678151",
+            "long_hair": "0.96172965",
+            "detached_sleeves": "0.9510404",
+            "ahoge": "0.94540447",
+            "gloves": "0.9342438",
+            "purple_eyes": "0.9304822",
+            "bell": "0.92110497",
+            "orb": "0.9137795",
+            "breasts": "0.9032445",
+            "looking_at_viewer": "0.90013504",
+            "black_gloves": "0.862591",
+            "white_background": "0.8615776",
+            "bare_shoulders": "0.8545493",
+            "smile": "0.82447666",
+            "medium_breasts": "0.8215981",
+            "neck_bell": "0.79515177",
+            "thighlet": "0.7304673",
+            "sidelocks": "0.7278657",
+            "vision_(genshin_impact)": "0.6980954",
+            "standing": "0.690362",
+            "white_sleeves": "0.6442809",
+            "tassel": "0.6387444",
+            "gold_trim": "0.612045",
+            "simple_background": "0.5703776",
+            "bow": "0.49510783",
+            "pantyhose": "0.46065962",
+            "waist_cape": "0.44340992",
+            "flower_knot": "0.4369225",
+            "bodystocking": "0.43336046",
+            "feet_out_of_frame": "0.42403945",
+            "low_ponytail": "0.40857768",
+            "chinese_knot": "0.4051522",
+            "long_sleeves": "0.36612618"
+        },
+        "Repo_id": "SmilingWolf/wd-vit-tagger-v3"
+    },
+    {
+        "Caption": "1girl, solo, horns, long_hair, blue_hair, detached_sleeves, gloves, ahoge, breasts, bell, looking_at_viewer, purple_eyes, orb, black_gloves, smile, bare_shoulders, medium_breasts, white_background, vision_(genshin_impact), neck_bell, gold_trim, white_sleeves, sidelocks, thighlet, standing, tassel, simple_background, pantyhose, bodystocking, low_ponytail, flower_knot, chinese_knot, long_sleeves, feet_out_of_frame, ganyu_(genshin_impact)",
+        "Tags": "1girl, solo, horns, long hair, blue hair, detached sleeves, gloves, ahoge, breasts, bell, looking at viewer, purple eyes, orb, black gloves, smile, bare shoulders, medium breasts, white background, vision \\(genshin impact\\), neck bell, gold trim, white sleeves, sidelocks, thighlet, standing, tassel, simple background, pantyhose, bodystocking, low ponytail, flower knot, chinese knot, long sleeves, feet out of frame, ganyu \\(genshin impact\\)",
+        "Ratings": {
+            "general": "0.09444821",
+            "sensitive": "0.9110725",
+            "questionable": "0.001273665",
+            "explicit": "0.00019249455"
+        },
+        "Character": {
+            "ganyu_(genshin_impact)": "0.989583"
+        },
+        "General": {
+            "1girl": "0.9990073",
+            "solo": "0.986086",
+            "horns": "0.97691685",
+            "long_hair": "0.976655",
+            "blue_hair": "0.97018594",
+            "detached_sleeves": "0.9630663",
+            "gloves": "0.9528584",
+            "ahoge": "0.9466164",
+            "breasts": "0.939335",
+            "bell": "0.9139086",
+            "looking_at_viewer": "0.90088356",
+            "purple_eyes": "0.9004356",
+            "orb": "0.89351803",
+            "black_gloves": "0.8897617",
+            "smile": "0.8828965",
+            "bare_shoulders": "0.87559116",
+            "medium_breasts": "0.8694743",
+            "white_background": "0.8646937",
+            "vision_(genshin_impact)": "0.7989824",
+            "neck_bell": "0.7968426",
+            "gold_trim": "0.77870077",
+            "white_sleeves": "0.74657595",
+            "sidelocks": "0.7191376",
+            "thighlet": "0.7173794",
+            "standing": "0.6971251",
+            "tassel": "0.6534954",
+            "simple_background": "0.6306383",
+            "pantyhose": "0.60918325",
+            "bodystocking": "0.5880574",
+            "low_ponytail": "0.58335847",
+            "flower_knot": "0.55061",
+            "chinese_knot": "0.4911994",
+            "long_sleeves": "0.40371013",
+            "feet_out_of_frame": "0.36766034"
+        },
+        "Repo_id": "SmilingWolf/wd-swinv2-tagger-v3"
+    },
+    {
+        "Caption": "1girl, solo, long_hair, ahoge, horns, blue_hair, orb, detached_sleeves, gloves, bell, purple_eyes, breasts, looking_at_viewer, bare_shoulders, white_background, black_gloves, medium_breasts, neck_bell, vision_(genshin_impact), tassel, smile, white_sleeves, gold_trim, sidelocks, simple_background, standing, thighlet, bodystocking, pantyhose, flower_knot, chinese_knot, low_ponytail, bow, waist_cape, feet_out_of_frame, ganyu_(genshin_impact)",
+        "Tags": "1girl, solo, long hair, ahoge, horns, blue hair, orb, detached sleeves, gloves, bell, purple eyes, breasts, looking at viewer, bare shoulders, white background, black gloves, medium breasts, neck bell, vision \\(genshin impact\\), tassel, smile, white sleeves, gold trim, sidelocks, simple background, standing, thighlet, bodystocking, pantyhose, flower knot, chinese knot, low ponytail, bow, waist cape, feet out of frame, ganyu \\(genshin impact\\)",
+        "Ratings": {
+            "general": "0.11932882",
+            "sensitive": "0.87867385",
+            "questionable": "0.0012409396",
+            "explicit": "0.00015736303"
+        },
+        "Character": {
+            "ganyu_(genshin_impact)": "0.9868869"
+        },
+        "General": {
+            "1girl": "0.99817467",
+            "solo": "0.99103117",
+            "long_hair": "0.9574774",
+            "ahoge": "0.957307",
+            "horns": "0.9566982",
+            "blue_hair": "0.953568",
+            "orb": "0.9492937",
+            "detached_sleeves": "0.94679636",
+            "gloves": "0.946109",
+            "bell": "0.93114275",
+            "purple_eyes": "0.9196103",
+            "breasts": "0.9013523",
+            "looking_at_viewer": "0.8901093",
+            "bare_shoulders": "0.8684672",
+            "white_background": "0.8641212",
+            "black_gloves": "0.8531206",
+            "medium_breasts": "0.8330931",
+            "neck_bell": "0.7989295",
+            "vision_(genshin_impact)": "0.793058",
+            "tassel": "0.78462917",
+            "smile": "0.77972054",
+            "white_sleeves": "0.72669303",
+            "gold_trim": "0.68204206",
+            "sidelocks": "0.6696157",
+            "simple_background": "0.64645475",
+            "standing": "0.6338763",
+            "thighlet": "0.6263255",
+            "bodystocking": "0.6048315",
+            "pantyhose": "0.53592044",
+            "flower_knot": "0.48086384",
+            "chinese_knot": "0.4745855",
+            "low_ponytail": "0.4641142",
+            "bow": "0.4116591",
+            "waist_cape": "0.38854668",
+            "feet_out_of_frame": "0.35137108"
+        },
+        "Repo_id": "SmilingWolf/wd-convnext-tagger-v3"
+    }
+]
+
+```
+
+</details>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 diffusers
+glob
 huggingface-hub
+json
 numpy
 pandas
 pillow >= 9.5.0

--- a/wdv3_timm.py
+++ b/wdv3_timm.py
@@ -400,6 +400,8 @@ class ScriptOptions:
             # transform to list
             self.model = self.model.split(',')
             print(self.model)
+        else:
+            self.model = [self.model]
         for model in self.model:
             if model not in valid_models:
                 raise ValueError(f"Invalid model. Must be one of: {valid_models}")

--- a/wdv3_timm.py
+++ b/wdv3_timm.py
@@ -1,6 +1,12 @@
-from dataclasses import dataclass
+#!/usr/bin/env python3
+
+from dataclasses import field, dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List, Dict
+
+import json
+import glob
+import os
 
 import numpy as np
 import pandas as pd
@@ -20,7 +26,6 @@ MODEL_REPO_MAP = {
     "swinv2": "SmilingWolf/wd-swinv2-tagger-v3",
     "convnext": "SmilingWolf/wd-convnext-tagger-v3",
 }
-
 
 def pil_ensure_rgb(image: Image.Image) -> Image.Image:
     # convert to RGB/RGBA if not already (deals with palette images etc.)
@@ -108,94 +113,213 @@ def get_tags(
 
     return caption, taglist, rating_labels, char_labels, gen_labels
 
+def write_to_json(image_path: Path, caption: str, taglist: List[str], ratings: Dict[str, float], character: Dict[str, float], general: Dict[str, float], repo_id: str) -> None:
+
+    # Create the full path for the json file
+    json_file_path = get_json_filepath(image_path)
+    print("JSON FILE: "+json_file_path)
+
+    # Create the json data
+    data = {
+        "Caption": caption,
+        "Tags": taglist,
+        "Ratings": {k: str(v) for k, v in ratings.items()},
+        "Character": {k: str(v) for k, v in character.items()},
+        "General": {k: str(v) for k, v in general.items()},
+        "Repo_id": repo_id
+    }
+
+    # Check if the json file already exists
+    if os.path.exists(json_file_path):
+        # Get the original file size
+        original_size = os.path.getsize(json_file_path)
+
+        # If it exists, load the existing data and append the new data
+        with open(json_file_path, 'r') as f:
+            existing_data = json.load(f)
+
+        # Append the new data to the existing data
+        existing_data.append(data)
+
+        try:
+            with open(json_file_path, 'w') as f:
+                json.dump(existing_data, f, indent=4)
+            # Get the new file size
+            new_size = os.path.getsize(json_file_path)
+
+            if new_size > original_size:
+                print(f"JSON data successfully written to {json_file_path} (updated from {original_size} bytes to {new_size} bytes)")
+            else:
+                print(f"Warning: File size did not increase after writing to {json_file_path} (remained at {original_size} bytes)")
+
+        except IOError as e:
+            print(f"Error writing JSON data to {json_file_path}: {e}")
+        except Exception as e:
+            print(f"An unexpected error occurred: {e}")
+    else:
+        try:
+            with open(json_file_path, 'w') as f:
+                json.dump([data], f, indent=4)
+            print(f"JSON data successfully written to {json_file_path}")
+        except IOError as e:
+            print(f"Error writing JSON data to {json_file_path}: {e}")
+        except Exception as e:
+            print(f"An unexpected error occurred: {e}")
+
+def get_json_filepath(image_path: str = ""):
+
+    image_name = os.path.splitext(os.path.basename(image_path))[0]
+
+    # Create the json file name with the same name as the image
+    json_file_name = f"{image_name}.json"
+
+    # Get the directory of the image
+    image_dir = os.path.dirname(image_path)
+
+    # Create the full path for the json file
+    json_file_path = os.path.join(image_dir, json_file_name)
+    return str(json_file_path)
+
+
+def print_results(image_path: Path, caption: str, taglist: List[str], ratings: Dict[str, float], character: Dict[str, float], general: Dict[str, float], repo_id: str) -> None:
+        print("--------")
+        print(f"Caption: {caption}")
+        print("--------")
+        print(f"Tags: {taglist}")
+
+        print("--------")
+        print("Ratings:")
+        for k, v in ratings.items():
+            print(f"  {k}: {v:.3f}")
+
+        print("--------")
+        print(f"Character tags (threshold={opts.char_threshold}):")
+        for k, v in character.items():
+            print(f"  {k}: {v:.3f}")
+
+        print("--------")
+        print(f"General tags (threshold={opts.gen_threshold}):")
+        for k, v in general.items():
+            print(f"  {k}: {v:.3f}")
 
 @dataclass
 class ScriptOptions:
-    image_file: Path = field(positional=True)
-    model: str = field(default="vit")
+    image_file: list[Path] = field(positional=True, metadata={"nargs": "+"})
+    model: str = field(default="vit", metadata={"help": "Model to use. Options: "+str(list(MODEL_REPO_MAP.keys()) + ['all'])})
     gen_threshold: float = field(default=0.35)
     char_threshold: float = field(default=0.75)
+    json: bool = field(default=False)
+    print: bool = field(default=False)
+
+    def __post_init__(self):
+        expanded_files = []
+        for file in self.image_file:
+            if not file.is_file() and '*' not in str(file):
+                raise ValueError("image_file must be a single file or a file glob")
+            if '*' in str(file):
+                expanded_files.extend(glob.glob(str(file)))
+            else:
+                expanded_files.append(file)
+
+        if not expanded_files:
+            raise ValueError("No files found")
+
+        for file in expanded_files:
+            if not Path(file).is_file():
+                raise ValueError(f"{file} is not a file")
+
+        self.image_file = expanded_files
+
+        valid_models = list(MODEL_REPO_MAP.keys()) + ['all']
+        if self.model not in valid_models:
+            raise ValueError(f"Invalid model. Must be one of: {valid_models}")
 
 
 def main(opts: ScriptOptions):
-    repo_id = MODEL_REPO_MAP.get(opts.model)
-    image_path = Path(opts.image_file).resolve()
-    if not image_path.is_file():
-        raise FileNotFoundError(f"Image file not found: {image_path}")
+    if opts.model == "all":
+        # Use all models, useful to compare model outputs
+        tagger_list = list(MODEL_REPO_MAP.keys())
+    else :
+        tagger_list = list(opt.model)
 
-    print(f"Loading model '{opts.model}' from '{repo_id}'...")
-    model: nn.Module = timm.create_model("hf-hub:" + repo_id).eval()
-    state_dict = timm.models.load_state_dict_from_hf(repo_id)
-    model.load_state_dict(state_dict)
+    model_number = 1
+    for tagger_model in tagger_list:
+        opts.model = tagger_model
+        repo_id = MODEL_REPO_MAP.get(opts.model)
 
-    print("Loading tag list...")
-    labels: LabelData = load_labels_hf(repo_id=repo_id)
+        print(f"Loading model '{opts.model}' from '{repo_id}'...")
+        model: nn.Module = timm.create_model("hf-hub:" + str(repo_id)).eval()
+        state_dict = timm.models.load_state_dict_from_hf(repo_id)
+        model.load_state_dict(state_dict)
 
-    print("Creating data transform...")
-    transform = create_transform(**resolve_data_config(model.pretrained_cfg, model=model))
+        print("Loading tag list...")
+        labels: LabelData = load_labels_hf(repo_id=repo_id)
 
-    print("Loading image and preprocessing...")
-    # get image
-    img_input: Image.Image = Image.open(image_path)
-    # ensure image is RGB
-    img_input = pil_ensure_rgb(img_input)
-    # pad to square with white background
-    img_input = pil_pad_square(img_input)
-    # run the model's input transform to convert to tensor and rescale
-    inputs: Tensor = transform(img_input).unsqueeze(0)
-    # NCHW image RGB to BGR
-    inputs = inputs[:, [2, 1, 0]]
+        print("Creating data transform...")
+        transform = create_transform(**resolve_data_config(model.pretrained_cfg, model=model))
 
-    print("Running inference...")
-    with torch.inference_mode():
-        # move model to GPU, if available
-        if torch_device.type != "cpu":
-            model = model.to(torch_device)
-            inputs = inputs.to(torch_device)
-        # run the model
-        outputs = model.forward(inputs)
-        # apply the final activation function (timm doesn't support doing this internally)
-        outputs = F.sigmoid(outputs)
-        # move inputs, outputs, and model back to to cpu if we were on GPU
-        if torch_device.type != "cpu":
-            inputs = inputs.to("cpu")
-            outputs = outputs.to("cpu")
-            model = model.to("cpu")
+        if not opts.image_file :
+            print("NO IMAGE LIST !! Should not happen")
+            exit(1)
 
-    print("Processing results...")
-    caption, taglist, ratings, character, general = get_tags(
-        probs=outputs.squeeze(0),
-        labels=labels,
-        gen_threshold=opts.gen_threshold,
-        char_threshold=opts.char_threshold,
-    )
+        # process each images with the same model, keeping the model loaded to go faster
+        image_nb = 0
+        image_total = len(opts.image_file)
+        for image_path in opts.image_file:
 
-    print("--------")
-    print(f"Caption: {caption}")
-    print("--------")
-    print(f"Tags: {taglist}")
+            print(f"Loading image {image_nb}/{image_total} and preprocessing with {opts.model}")
+            # get image
+            img_input: Image.Image = Image.open(image_path)
+            # ensure image is RGB
+            img_input = pil_ensure_rgb(img_input)
+            # pad to square with white background
+            img_input = pil_pad_square(img_input)
+            # run the model's input transform to convert to tensor and rescale
+            inputs: Tensor = transform(img_input).unsqueeze(0)
+            # NCHW image RGB to BGR
+            inputs = inputs[:, [2, 1, 0]]
 
-    print("--------")
-    print("Ratings:")
-    for k, v in ratings.items():
-        print(f"  {k}: {v:.3f}")
+            print("Running inference...")
+            with torch.inference_mode():
+                # move model to GPU, if available
+                if torch_device.type != "cpu":
+                    model = model.to(torch_device)
+                    inputs = inputs.to(torch_device)
+                # run the model
+                outputs = model.forward(inputs)
+                # apply the final activation function (timm doesn't support doing this internally)
+                outputs = F.sigmoid(outputs)
+                # move inputs, outputs, and model back to to cpu if we were on GPU
+                if torch_device.type != "cpu":
+                    inputs = inputs.to("cpu")
+                    outputs = outputs.to("cpu")
+                    model = model.to("cpu")
 
-    print("--------")
-    print(f"Character tags (threshold={opts.char_threshold}):")
-    for k, v in character.items():
-        print(f"  {k}: {v:.3f}")
+            print("Processing results...")
+            caption, taglist, ratings, character, general = get_tags(
+                probs=outputs.squeeze(0),
+                labels=labels,
+                gen_threshold=opts.gen_threshold,
+                char_threshold=opts.char_threshold,
+            )
 
-    print("--------")
-    print(f"General tags (threshold={opts.gen_threshold}):")
-    for k, v in general.items():
-        print(f"  {k}: {v:.3f}")
+            image_nb +=1
 
-    print("Done!")
+            if opts.json:
+                write_to_json(image_path, caption, taglist, ratings, character, general, repo_id=repo_id)
+                print("Wrote to json file : "+ get_json_filepath(image_path))
+
+            if not opts.json or opts.print:
+                print_results(image_path=image_path, caption=caption, taglist=taglist, ratings=ratings, character=character, general=general, repo_id=repo_id)
+
+        print("Done!")
 
 
 if __name__ == "__main__":
     opts, _ = parse_known_args(ScriptOptions)
-    if opts.model not in MODEL_REPO_MAP:
-        print(f"Available models: {list(MODEL_REPO_MAP.keys())}")
-        raise ValueError(f"Unknown model name '{opts.model}'")
+    # Now handled with @dataclass
+    # if opts.model not in MODEL_REPO_MAP or opts.model != "all":
+    #     print(f"Available models: {list(MODEL_REPO_MAP.keys())}")
+    #     print("You may request for the image to be tested against all models by passing --model=all.")
+    #     raise ValueError(f"Unknown model name '{opts.model}'")
     main(opts)

--- a/wdv3_timm.py
+++ b/wdv3_timm.py
@@ -199,6 +199,7 @@ def write_to_json(image_path: Path, caption: str, taglist: List[str], ratings: D
         # Append the new data to the existing data
         existing_data.append(data)
 
+        # summary will be True when it's time to write the last model's results to JSON
         if summary:
             pattern = ':>='  # pattern to remove
 
@@ -395,8 +396,16 @@ class ScriptOptions:
         self.image_file = expanded_files
 
         valid_models = list(MODEL_REPO_MAP.keys()) + ['all']
-        if self.model not in valid_models:
-            raise ValueError(f"Invalid model. Must be one of: {valid_models}")
+        if ',' in self.model:
+            # transform to list
+            self.model = self.model.split(',')
+            print(self.model)
+        for model in self.model:
+            if model not in valid_models:
+                raise ValueError(f"Invalid model. Must be one of: {valid_models}")
+
+        if 'all' in self.model:
+            self.model = list(MODEL_REPO_MAP.keys())
 
 
 def main(opts: ScriptOptions):
@@ -404,7 +413,11 @@ def main(opts: ScriptOptions):
         # Use all models, useful to compare model outputs
         tagger_list = list(MODEL_REPO_MAP.keys())
     else :
-        tagger_list = list(opt.model)
+        if not opts.model == type(list):
+            tagger_list = list(opts.model)
+        else:
+            # it's already a list of models
+            tagger_list = opts.model
 
     model_number = 1
     for tagger_model in tagger_list:
@@ -470,6 +483,7 @@ def main(opts: ScriptOptions):
             image_nb +=1
 
             if opts.json:
+                # Want summary, it's the last model and there is more than one model
                 if opts.summary and len(tagger_list) > 1 and model_number == len(tagger_list):
                     summary=True
                 else:


### PR DESCRIPTION
Hi, thanks for your work !

I changed a few things to make it work faster on my side, offering it back.

## Multiple models
It will now allow `--model=all` and `--model=vit,convnext` that will help to evaluate model performance.

## Multiple file 
- It will allow multiple file input. Normal usage is not affected for a single file. 
- It also support `*` globs that will be parsed inside python as well as normal shell expansion of file list.
- Will do all files with a specific model first to keep the model loaded, saving lots of time. 
- TODO: Benchmark the speedup. *Sorry I will not do it.*

## JSON export
Allow output to JSON with `--json` flag. Will not overwrite already existing files, but append to them.
If `--json` is set it will not print results, less clogging when doing multiple models, use `--print` to force it to print.
It logs the model used in the JSON output only.

### JSON Summary
It's just a list of best tags as well as highest score. Also list what model have the winning score.
Use with `--json --summary`

Updated `README.md` for more details, updated `requirements.txt`.

# Possible enhancements
- ~~Forgot to enable multi model selection, like `--model=vit,convnext` but I won't use it, in worst case, I'll just edit `MODEL_REPO_MAP`.~~
- JSON output to other directory ?
- Add more models or checkpoints ?
- Support URL and url.txt as input ?

